### PR TITLE
Convert interpolated variables and strings prefixed with `~` 

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ Less2Sass.prototype.convert = function(file) {
 
   this.file = file;
 
-  this.convertVariables()
+  this.convertInterpolatedVariables()
+      .convertVariables()
       .convertMixins()
       .includeMixins()
       .convertColourHelpers();
@@ -28,7 +29,7 @@ Less2Sass.prototype.convertMixins = function() {
   var mixinRegex = /\.([\w\-]*)\s*\((.*)\)\s*\{/g;
 
   this.file = this.file.replace(mixinRegex, '@mixin $1($2) {');
-  
+
   return this;
 };
 
@@ -38,6 +39,14 @@ Less2Sass.prototype.convertColourHelpers = function() {
   this.file = this.file.replace(helperRegex, 'adjust-hue(');
 
   // TODO (EK): Flag other colour helpers for manual conversion that SASS does not have
+
+  return this;
+};
+
+Less2Sass.prototype.convertInterpolatedVariables = function() {
+  var interpolationRegex = /@\{(?!(\s|\())/g;
+
+  this.file = this.file.replace(interpolationRegex, '#{$');
 
   return this;
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ Less2Sass.prototype.convert = function(file) {
 
   this.convertInterpolatedVariables()
       .convertVariables()
+      .convertTildaStrings()
       .convertMixins()
       .includeMixins()
       .convertColourHelpers();
@@ -39,6 +40,14 @@ Less2Sass.prototype.convertColourHelpers = function() {
   this.file = this.file.replace(helperRegex, 'adjust-hue(');
 
   // TODO (EK): Flag other colour helpers for manual conversion that SASS does not have
+
+  return this;
+};
+
+Less2Sass.prototype.convertTildaStrings = function() {
+  var tildaRegex = /~("|')/g;
+
+  this.file = this.file.replace(tildaRegex, '$1');
 
   return this;
 };

--- a/test/fixtures/test.less
+++ b/test/fixtures/test.less
@@ -4,6 +4,8 @@
 
 // variables
 @black: #000;
+@san-serif-stack: helvetica, arial;
+@standard-fonts: ~'@{san-serif-stack}, sans-serif';
 
 // mixins
 .box-sizing (@sizing:border-box) {
@@ -37,6 +39,7 @@
 
     &:hover {
       background: lighten(@black, 10%);
+      filter: ~"progid:DXImageTransform.Microsoft.gradient(startColorstr=@{black}, endColorstr=@{black})";
     }
   }
 }

--- a/test/fixtures/test.scss
+++ b/test/fixtures/test.scss
@@ -4,6 +4,8 @@
 
 // variables
 $black: #000;
+$san-serif-stack: helvetica, arial;
+$standard-fonts: ~'#{$san-serif-stack}, sans-serif';
 
 // mixins
 @mixin box-sizing($sizing:border-box) {
@@ -37,6 +39,7 @@ $black: #000;
 
     &:hover {
       background: lighten($black, 10%);
+      filter: ~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#{$black}, endColorstr=#{$black})";
     }
   }
 }

--- a/test/fixtures/test.scss
+++ b/test/fixtures/test.scss
@@ -5,7 +5,7 @@
 // variables
 $black: #000;
 $san-serif-stack: helvetica, arial;
-$standard-fonts: ~'#{$san-serif-stack}, sans-serif';
+$standard-fonts: '#{$san-serif-stack}, sans-serif';
 
 // mixins
 @mixin box-sizing($sizing:border-box) {
@@ -39,7 +39,7 @@ $standard-fonts: ~'#{$san-serif-stack}, sans-serif';
 
     &:hover {
       background: lighten($black, 10%);
-      filter: ~"progid:DXImageTransform.Microsoft.gradient(startColorstr=#{$black}, endColorstr=#{$black})";
+      filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#{$black}, endColorstr=#{$black})";
     }
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ describe('less2sass', function() {
   describe("variables", function() {
     it('converts interpolated variables to #{$', function() {
       var result = less2sass.convert('@san-serif-stack: helvetica, arial; @standard-fonts: ~\'@{san-serif-stack}, sans-serif\';');
-      assert.equal(result, '$san-serif-stack: helvetica, arial; $standard-fonts: ~\'#{$san-serif-stack}, sans-serif\';');
+      assert.equal(result, '$san-serif-stack: helvetica, arial; $standard-fonts: \'#{$san-serif-stack}, sans-serif\';');
     });
 
     it('converts @ for variables to $', function() {
@@ -69,6 +69,18 @@ describe('less2sass', function() {
     it('does not convert @ to $ for @font-face statements', function() {
       var result = less2sass.convert('@font-face {}');
       assert.equal(result, '@font-face {}');
+    });
+  });
+
+  describe("~ strings", function() {
+    it('converts ~\'\' to \'\'', function() {
+      var result = less2sass.convert('~\'san-serif\'');
+      assert.equal(result, '\'san-serif\'');
+    });
+
+    it('converts ~"" to ""', function() {
+      var result = less2sass.convert('~"san-serif"');
+      assert.equal(result, '"san-serif"');
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,11 @@ describe('less2sass', function() {
   });
 
   describe("variables", function() {
+    it('converts interpolated variables to #{$', function() {
+      var result = less2sass.convert('@san-serif-stack: helvetica, arial; @standard-fonts: ~\'@{san-serif-stack}, sans-serif\';');
+      assert.equal(result, '$san-serif-stack: helvetica, arial; $standard-fonts: ~\'#{$san-serif-stack}, sans-serif\';');
+    });
+
     it('converts @ for variables to $', function() {
       var result = less2sass.convert('@var1: #000;');
       assert.equal(result, '$var1: #000;');


### PR DESCRIPTION
Strings containing interpolated variables `'string@{variableName}'` should be converted `'string#{$variableName}'`. Strings that are prefixed with `~'string'` should be converted to `'string'`.