### PR TITLE
Convert unit() less function

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ Less2Sass.prototype.convert = function(file) {
       .convertMixins()
       .includeMixins()
       .convertColourHelpers()
-      .convertFileExtensions();
+      .convertFileExtensions()
+      .convertFunctionUnit();
 
   return this.file;
 };
@@ -31,6 +32,17 @@ Less2Sass.prototype.convertMixins = function() {
   var mixinRegex = /^(\s*?)\.([\w\-]*?)\s*\(([\s\S][^\)]+?)\)+\s*\{$/gm;
 
   this.file = this.file.replace(mixinRegex, '$1@mixin $2($3) {');
+
+  return this;
+};
+
+Less2Sass.prototype.convertFunctionUnit = function() {
+  // Two-arg.
+  const unitTwoArgRegex = /unit\((\S+),(\S+)\)/g;
+  // TODO Check for unit on the first arg.
+  this.file = this.file.replace(unitTwoArgRegex, '$1$2');
+  const unitOneArgRegex = /unit\(([^,]+)\)/g;
+  this.file = this.file.replace(unitOneArgRegex, 'unit-less($1)');
 
   return this;
 };

--- a/index.js
+++ b/index.js
@@ -37,13 +37,10 @@ Less2Sass.prototype.convertMixins = function() {
 };
 
 Less2Sass.prototype.convertFunctionUnit = function() {
-  // Two-args with variable as dimension.
-  const unitTwoArgVariableRegex = /unit\((\$\S+),(\S+)\)/g;
-  this.file = this.file.replace(unitTwoArgVariableRegex, '$1*1$2');
   // Two-args.
   const unitTwoArgRegex = /unit\((\S+),(\S+)\)/g;
-  // TODO Check for unit on the first arg.
-  this.file = this.file.replace(unitTwoArgRegex, '$1$2');
+  this.file = this.file.replace(unitTwoArgRegex, '0$2 + $1');
+  // One-arg.
   const unitOneArgRegex = /unit\(([^,]+)\)/g;
   this.file = this.file.replace(unitOneArgRegex, 'unit-less($1)');
 

--- a/index.js
+++ b/index.js
@@ -37,7 +37,10 @@ Less2Sass.prototype.convertMixins = function() {
 };
 
 Less2Sass.prototype.convertFunctionUnit = function() {
-  // Two-arg.
+  // Two-args with variable as dimension.
+  const unitTwoArgVariableRegex = /unit\((\$\S+),(\S+)\)/g;
+  this.file = this.file.replace(unitTwoArgVariableRegex, '$1*1$2');
+  // Two-args.
   const unitTwoArgRegex = /unit\((\S+),(\S+)\)/g;
   // TODO Check for unit on the first arg.
   this.file = this.file.replace(unitTwoArgRegex, '$1$2');

--- a/test/index.js
+++ b/test/index.js
@@ -157,6 +157,10 @@ describe('less2sass', function() {
         const result = less2sass.convert('unit(5em,px)');
         assert.equal(result, '0px + 5em');
       });
+      it('manage variable in first dimension', function() {
+        const result = less2sass.convert('unit($size,px)');
+        assert.equal(result, '$size*1px');
+      });
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -150,16 +150,16 @@ describe('less2sass', function() {
       });
       it('convert two param call of less unit without unit in first param to dimension + unit', function() {
         const result = less2sass.convert('unit(42,px)');
-        assert.equal(result, '42px');
+        assert.equal(result, '0px + 42');
       });
       it('convert two param call of less unit with unit in first param to unit conversion', function() {
         // https://www.sitepoint.com/understanding-sass-units/
-        const result = less2sass.convert('unit(5em,px)');
-        assert.equal(result, '0px + 5em');
+        const result = less2sass.convert('unit(5in,px)');
+        assert.equal(result, '0px + 5in');
       });
-      it('manage variable in first dimension', function() {
+      it('manage variable in first param', function() {
         const result = less2sass.convert('unit($size,px)');
-        assert.equal(result, '$size*1px');
+        assert.equal(result, '0px + $size');
       });
     });
   });

--- a/test/index.js
+++ b/test/index.js
@@ -15,128 +15,148 @@ describe('less2sass', function() {
     });
 
     it('converts multiple variables in the same line', function() {
-      var result = less2sass.convert(fixture);
+      const result = less2sass.convert(fixture);
       assert.equal(result, expected);
     });
   });
 
   describe("variables", function() {
     it('converts interpolated variables to #{$', function() {
-      var result = less2sass.convert('@san-serif-stack: helvetica, arial; @standard-fonts: ~\'@{san-serif-stack}, sans-serif\';');
+      const result = less2sass.convert('@san-serif-stack: helvetica, arial; @standard-fonts: ~\'@{san-serif-stack}, sans-serif\';');
       assert.equal(result, '$san-serif-stack: helvetica, arial; $standard-fonts: \'#{$san-serif-stack}, sans-serif\';');
     });
 
     it('converts @ for variables to $', function() {
-      var result = less2sass.convert('@var1: #000;');
+      const result = less2sass.convert('@var1: #000;');
       assert.equal(result, '$var1: #000;');
     });
 
     it('converts multiple variables in the same line', function() {
-      var result = less2sass.convert('@var1: #000; @var2: #fff;');
+      const result = less2sass.convert('@var1: #000; @var2: #fff;');
       assert.equal(result, '$var1: #000; $var2: #fff;');
     });
 
     it('still converts variables have the word "media" in them', function() {
-      var result = less2sass.convert('@mediaType: screen;');
+      const result = less2sass.convert('@mediaType: screen;');
       assert.equal(result, '$mediaType: screen;');
     });
 
     it('still converts variables have the word "import" in them', function() {
-      var result = less2sass.convert('@importType: screen;');
+      const result = less2sass.convert('@importType: screen;');
       assert.equal(result, '$importType: screen;');
     });
 
     it('still converts variables have the word "import" in them', function() {
-      var result = less2sass.convert('@mixinType: screen;');
+      const result = less2sass.convert('@mixinType: screen;');
       assert.equal(result, '$mixinType: screen;');
     });
 
     it('does not convert @ to $ for media queries', function() {
-      var result = less2sass.convert('@media(min-width:768px) {}');
+      const result = less2sass.convert('@media(min-width:768px) {}');
       assert.equal(result, '@media(min-width:768px) {}');
     });
 
     it('does not convert @ to $ for @mixin statements', function() {
-      var result = less2sass.convert('@mixin screen() {}');
+      const result = less2sass.convert('@mixin screen() {}');
       assert.equal(result, '@mixin screen() {}');
     });
 
     it('does not convert @ to $ for @import statements', function() {
-      var result = less2sass.convert('@import "common"');
+      const result = less2sass.convert('@import "common"');
       assert.equal(result, '@import "common"');
     });
 
     it('does not convert @ to $ for @font-face statements', function() {
-      var result = less2sass.convert('@font-face {}');
+      const result = less2sass.convert('@font-face {}');
       assert.equal(result, '@font-face {}');
     });
 
     it('does not convert @ to $ for @keyframes statements', function() {
-      var result = less2sass.convert('@keyframes {}');
+      const result = less2sass.convert('@keyframes {}');
       assert.equal(result, '@keyframes {}');
     });
   });
 
   describe("~ strings", function() {
     it('converts ~\'\' to \'\'', function() {
-      var result = less2sass.convert('~\'san-serif\'');
+      const result = less2sass.convert('~\'san-serif\'');
       assert.equal(result, '\'san-serif\'');
     });
 
     it('converts ~"" to ""', function() {
-      var result = less2sass.convert('~"san-serif"');
+      const result = less2sass.convert('~"san-serif"');
       assert.equal(result, '"san-serif"');
     });
   });
 
   describe("colour helpers", function() {
     it('converts spin function to adjust-hue', function() {
-      var result = less2sass.convert('spin(#aaaaaa, 10)');
+      const result = less2sass.convert('spin(#aaaaaa, 10)');
       assert.equal(result, 'adjust-hue(#aaaaaa, 10)');
     });
   });
 
   describe("mixins", function() {
     it('converts mixin declarations to use the @mixins syntax', function() {
-      var result = less2sass.convert('.drop-shadow(@x-axis: 0, @y-axis: 1px, @blur: 2px, @alpha: 0.1) {\n}');
+      const result = less2sass.convert('.drop-shadow(@x-axis: 0, @y-axis: 1px, @blur: 2px, @alpha: 0.1) {\n}');
       assert.equal(result, '@mixin drop-shadow($x-axis: 0, $y-axis: 1px, $blur: 2px, $alpha: 0.1) {\n}');
     });
 
     it('converts mixin declarations with new lines in param list and retains the new lines', function() {
-      var result = less2sass.convert('.drop-shadow(\n @x-axis: 0,\n @y-axis: 1px,\n @blur: 2px,\n @alpha: 0.1) {\n}');
+      const result = less2sass.convert('.drop-shadow(\n @x-axis: 0,\n @y-axis: 1px,\n @blur: 2px,\n @alpha: 0.1) {\n}');
       assert.equal(result, '@mixin drop-shadow(\n $x-axis: 0,\n $y-axis: 1px,\n $blur: 2px,\n $alpha: 0.1) {\n}');
     });
 
     it('converts mixin call without argments to use the @include syntax', function() {
-      var result = less2sass.convert('.box-sizing();');
+      const result = less2sass.convert('.box-sizing();');
       assert.equal(result, '@include box-sizing();');
     });
 
     it('converts mixin call in shorthand form to use the @include syntax', function() {
-      var result = less2sass.convert('.box-sizing;');
+      const result = less2sass.convert('.box-sizing;');
       assert.equal(result, '@include box-sizing;');
     });
 
     it('converts mixin call with arguments to use the @include syntax', function() {
-      var result = less2sass.convert('.drop-shadow(0, 2px, 4px, 0.4);');
+      const result = less2sass.convert('.drop-shadow(0, 2px, 4px, 0.4);');
       assert.equal(result, '@include drop-shadow(0, 2px, 4px, 0.4);');
     });
 
     it('does not convert .foo .bar', function() {
-      var result = less2sass.convert('.foo .bar {}');
+      const result = less2sass.convert('.foo .bar {}');
       assert.equal(result, '.foo .bar {}');
     });
 
     it('does not convert .5em (or similar)', function() {
-      var result = less2sass.convert('font-size: .5em;');
+      const result = less2sass.convert('font-size: .5em;');
       assert.equal(result, 'font-size: .5em;');
     });
   });
 
   describe('imports', function() {
     it('convert imports with the .less extension to .scss', function() {
-      var result = less2sass.convert('@import \'app/app.less\';');
+      const result = less2sass.convert('@import \'app/app.less\';');
       assert.equal(result, '@import \'app/app.scss\';');
+    });
+  });
+
+  describe('functions', function() {
+    describe('unit', function() {
+      // http://lesscss.org/functions/#misc-functions-unit
+      it('convert one param call of less unit to sass unit-less', function() {
+        // http://sass-lang.com/documentation/Sass/Script/Functions.html#unitless-instance_method
+        const result = less2sass.convert('unit(5em)');
+        assert.equal(result, 'unit-less(5em)');
+      });
+      it('convert two param call of less unit without unit in first param to dimension + unit', function() {
+        const result = less2sass.convert('unit(42,px)');
+        assert.equal(result, '42px');
+      });
+      it('convert two param call of less unit with unit in first param to unit conversion', function() {
+        // https://www.sitepoint.com/understanding-sass-units/
+        const result = less2sass.convert('unit(5em,px)');
+        assert.equal(result, '0px + 5em');
+      });
     });
   });
 


### PR DESCRIPTION
Hey there!

I've tried to add conversion of the [unit()](lesscss.org/functions/#misc-functions-unit) function of Less.

What I (intended to) do is the following:
* if we have a call to `unit()` with only one param, this must be to delete the unit, thus we call instead the Sass `unit-less()` function;
* if we have a call to `unit()` with two params, (I think) we can always express it as an unit conversion in Sass (that is: `0<unit> * <value>`)

There are some conversion test cases for the feature I propose. If you see any issue with the conversion, please tell me, I'm by far not a Less and Sass expert!

Peace