### PR TITLE
support @-webkit-keyframes

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ Less2Sass.prototype.convertInterpolatedVariables = function() {
 
 Less2Sass.prototype.convertVariables = function() {
   // Matches any @ that doesn't have 'media ' or 'import ' after it.
-  var atRegex = /@(?!(media|import|mixin|font-face|keyframes)(\s|\())/g;
+  var atRegex = /@(?!(media|import|mixin|font-face|keyframes|-webkit-keyframes)(\s|\())/g;
 
   this.file = this.file.replace(atRegex, '$');
 

--- a/test/fixtures/test.less
+++ b/test/fixtures/test.less
@@ -56,13 +56,22 @@
 
 // styles
 
+@-webkit-keyframes grow-font-size {
+  0% {
+    font-size: .5em;
+  }
+  100% {
+    font-size: 1em;
+  }
+}
+
 @keyframes grow-font-size {
-    0% {
-        font-size: .5em;
-    }
-    100% {
-        font-size: 1em;
-    }
+  0% {
+    font-size: .5em;
+  }
+  100% {
+    font-size: 1em;
+  }
 }
 
 #header {

--- a/test/fixtures/test.scss
+++ b/test/fixtures/test.scss
@@ -56,13 +56,22 @@ $standard-fonts: '#{$san-serif-stack}, sans-serif';
 
 // styles
 
+@-webkit-keyframes grow-font-size {
+  0% {
+    font-size: .5em;
+  }
+  100% {
+    font-size: 1em;
+  }
+}
+
 @keyframes grow-font-size {
-    0% {
-        font-size: .5em;
-    }
-    100% {
-        font-size: 1em;
-    }
+  0% {
+    font-size: .5em;
+  }
+  100% {
+    font-size: 1em;
+  }
 }
 
 #header {


### PR DESCRIPTION
Adds support & tests for `@-webkit-keyframes`, has the same behaviour as `@keyframes`. Before this PR, `@-webkit-keyframes` was not rewritten, resulting in an output (`$-webkit-keyframes`) which is not valid in scss.